### PR TITLE
Add support for rendering a request directly to a file

### DIFF
--- a/example/pragmatic.rb
+++ b/example/pragmatic.rb
@@ -12,20 +12,13 @@ BreezyPDFLite.setup do |config|
   config.middleware_path_matchers = [/as-pdf.pdf/]
 end
 
-response = BreezyPDFLite::RenderRequest.new(html).submit
+render_request = BreezyPDFLite::RenderRequest.new(html)
 
-if response.code.to_i == 201
-  path = File.expand_path("example.pdf", __dir__)
-
-  FileUtils.rm(File.expand_path("example.pdf", __dir__)) if File.exist?(path)
-  File.new(path, "w").tap do |file|
-    file.write(response.body)
-
-    file.flush
-    file.close
-  end
-
-  puts "Downloaded to #{path}"
-else
-  puts "Unable to render to PDF, server responded with #{response.code}"
+begin
+  tempfile = render_request.to_file
+  puts tempfile.path
+  puts "Enter to remove..."
+  gets
+rescue BreezyPDFLite::BreezyPDFLiteError => e
+  puts "Unable to render PDF: #{e.message}"
 end

--- a/lib/breezy_pdf_lite.rb
+++ b/lib/breezy_pdf_lite.rb
@@ -2,6 +2,7 @@
 
 require "uri"
 require "net/http"
+require "tempfile"
 
 require "breezy_pdf_lite/version"
 require "breezy_pdf_lite/util"

--- a/lib/breezy_pdf_lite/render_request.rb
+++ b/lib/breezy_pdf_lite/render_request.rb
@@ -11,7 +11,21 @@ module BreezyPDFLite
       client.post("/render/html", @body)
     end
 
+    def to_file
+      raise BreezyPDFLiteError, "#{response.code}: #{response.body}" if response.code != "201"
+
+      @to_file ||= Tempfile.new(%w[response .pdf]).tap do |file|
+        file.write(response.body)
+        file.flush
+        file.rewind
+      end
+    end
+
     private
+
+    def response
+      @response ||= submit
+    end
 
     def client
       @client ||= Client.new

--- a/test/render_request_test.rb
+++ b/test/render_request_test.rb
@@ -18,4 +18,22 @@ class BreezyPDFLite::RenderRequestTest < BreezyTest
 
     assert client_mock.verify
   end
+
+  def test_non_201_to_file
+    request = tested_class.new("blah")
+
+    request.stub(:submit, OpenStruct.new(code: "404")) do
+      assert_raises(BreezyPDFLite::BreezyPDFLiteError) do
+        request.to_file
+      end
+    end
+  end
+
+  def test_to_file
+    request = tested_class.new("blah")
+
+    request.stub(:submit, OpenStruct.new(code: "201", body: "blah")) do
+      assert_kind_of(Tempfile, request.to_file)
+    end
+  end
 end


### PR DESCRIPTION
Add `BreezyPDFLite::RenderRequest#to_file` for easier pragmatic PDF file generation.