### PR TITLE
Only strip pdf extensions from existing path

### DIFF
--- a/lib/breezy_pdf_lite/intercept/base.rb
+++ b/lib/breezy_pdf_lite/intercept/base.rb
@@ -30,9 +30,7 @@ module BreezyPDFLite::Intercept
     end
 
     def path
-      BreezyPDFLite.middleware_path_matchers.reduce(env["PATH_INFO"]) do |path, matcher|
-        path.gsub(matcher, "")
-      end
+      env["PATH_INFO"].gsub(/\.pdf/, "")
     end
 
     def query_string


### PR DESCRIPTION
Only strip the `/\.pdf/` from the path instead of the entire matching path. Backwards compatible for `middleware_path_matchers` default.

Fixes #29