### PR TITLE
Raise an error on render request failure

### DIFF
--- a/lib/breezy_pdf_lite.rb
+++ b/lib/breezy_pdf_lite.rb
@@ -17,7 +17,8 @@ module BreezyPDFLite
   autoload :Middleware,    "breezy_pdf_lite/middleware"
   autoload :RenderRequest, "breezy_pdf_lite/render_request"
 
-  BreezyPDFLiteError = Class.new(StandardError)
+  Error = Class.new(StandardError)
+  RenderError = Class.new(Error)
 
   mattr_accessor :secret_api_key
   @@secret_api_key = nil

--- a/lib/breezy_pdf_lite/intercept.rb
+++ b/lib/breezy_pdf_lite/intercept.rb
@@ -3,7 +3,7 @@
 module BreezyPDFLite
   # :nodoc
   module Intercept
-    UnRenderable = Class.new(BreezyPDFLiteError)
+    UnRenderable = Class.new(BreezyPDFLite::Error)
     autoload :Base, "breezy_pdf_lite/intercept/base"
     autoload :HTML, "breezy_pdf_lite/intercept/html"
   end

--- a/lib/breezy_pdf_lite/intercept/html.rb
+++ b/lib/breezy_pdf_lite/intercept/html.rb
@@ -8,6 +8,10 @@ module BreezyPDFLite::Intercept
 
       render_request = BreezyPDFLite::RenderRequest.new(body).submit
 
+      if render_request.status != "201"
+        raise BreezyPDFLite::RenderError, "Status: #{render_request.status} body: #{render_request.body}"
+      end
+
       [
         201,
         {

--- a/lib/breezy_pdf_lite/render_request.rb
+++ b/lib/breezy_pdf_lite/render_request.rb
@@ -12,7 +12,7 @@ module BreezyPDFLite
     end
 
     def to_file
-      raise BreezyPDFLiteError, "#{response.code}: #{response.body}" if response.code != "201"
+      raise RenderError, "#{response.code}: #{response.body}" if response.code != "201"
 
       @to_file ||= Tempfile.new(%w[response .pdf]).tap do |file|
         file.binmode

--- a/lib/breezy_pdf_lite/response.rb
+++ b/lib/breezy_pdf_lite/response.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+module BreezyPDFLite
+  # RenderRequest -> Net::HTTPResponse wrapper that is streaming compatable
+  class Response
+    def initialize(response)
+      @response = response
+    end
+
+    def status
+      @status ||= @response.code.to_i
+    end
+
+    def headers
+      {
+        "Content-Type" => "application/pdf",
+        "Content-Length" => @response.header["Content-Length"],
+        "Content-Disposition" => @response.header["Content-Disposition"]
+      }
+    end
+
+    def each(&blk)
+      @response.read_body(&blk)
+    end
+
+    def body
+      io = StringIO.new
+      io.binmode
+
+      each do |chunk|
+        io.write chunk
+      end
+
+      io.flush
+      io.rewind
+
+      io
+    end
+  end
+end

--- a/test/intercept/html_test.rb
+++ b/test/intercept/html_test.rb
@@ -9,6 +9,7 @@ class BreezyPDFLite::Intercept::HTMLTest < BreezyTest
 
   def mocks
     response = OpenStruct.new(
+      status: "201",
       header: {
         "Content-Length" => 1234
       },

--- a/test/render_request_test.rb
+++ b/test/render_request_test.rb
@@ -23,7 +23,7 @@ class BreezyPDFLite::RenderRequestTest < BreezyTest
     request = tested_class.new("blah")
 
     request.stub(:submit, OpenStruct.new(code: "404")) do
-      assert_raises(BreezyPDFLite::BreezyPDFLiteError) do
+      assert_raises(BreezyPDFLite::RenderError) do
         request.to_file
       end
     end


### PR DESCRIPTION
- Don't rescue render failures, allowing observability into failures end users might see
- Change error classes to be scoped to the `BreezyPDFLite` namespace.